### PR TITLE
Expose key + version with 'Hyperdrive-' HTTP headers

### DIFF
--- a/example.js
+++ b/example.js
@@ -6,7 +6,7 @@ var serve = require('.')
 
 var archive = hyperdrive(ram)
 
-var server = http.createServer(serve(archive))
+var server = http.createServer(serve(archive, {exposeHeaders: true}))
 
 archive.writeFile('readme.md', fs.readFileSync('readme.md'))
 archive.writeFile('package.json', fs.readFileSync('package.json'))

--- a/index.js
+++ b/index.js
@@ -74,6 +74,8 @@ function ondirectoryindex (archive, name, opts, req, res) {
     var html = toHTML({directory: name, script: archive._checkout ? null : script}, entries)
     res.setHeader('Content-Type', 'text/html; charset=utf-8')
     res.setHeader('Content-Length', Buffer.byteLength(html))
+    res.setHeader('Hyperdrive-Key', archive.key.toString('hex'))
+    res.setHeader('Hyperdrive-Version', archive.version)
     res.end(html)
   })
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var pump = require('pump')
 var mime = require('mime')
 var range = require('range-parser')
 var qs = require('querystring')
+var pkg = require('./package')
 
 module.exports = serve
 
@@ -79,6 +80,7 @@ function ondirectoryindex (archive, name, opts, req, res, exposeHeaders) {
     if (exposeHeaders) {
       res.setHeader('Hyperdrive-Key', archive.key.toString('hex'))
       res.setHeader('Hyperdrive-Version', archive.version)
+      res.setHeader('Hyperdrive-Http-Version', pkg.version)
     }
     res.end(html)
   })

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Hyperdrive works with many archives/feeds or a single archive.
 If you have multiple archives, you will need to look the archive to return using the key.
 
 Initiate with an archive lookup function:
-`var onrequest = hyperdriveHttp(getArchive)`
+`var onrequest = hyperdriveHttp(getArchive[, options])`
 
 The archive lookup function may look like this:
 
@@ -56,12 +56,20 @@ var getArchive = function (datInfo, cb) {
 Hyperdrive-http works great with a single archive too. It exposes the metadata at the root path and files are available without using the key.
 
 Pass a single archive on initiation:
-`var onrequest = hyperdriveHttp(archive)`
+`var onrequest = hyperdriveHttp(archive[, options])`
 
 Now your archive metadata will be available at http://example.com/
 
 #### Hypercore Feed(s)
-You can also use a hypercore feed: `hyperdriveHttp(feed)` (or using a similar getArchive function)
+You can also use a hypercore feed: `hyperdriveHttp(feed[, options])` (or using a similar getArchive function)
+
+#### Options
+
+- `exposeHeaders` - If set to `true`, hyperdrive-http will add custom `Hyperdrive-` HTTP headers to directory listing requests (default: `false`):
+  ```http
+  Hyperdrive-Key: de2a51bbaf8a5545eff82c999f15e1fd29637b3f16db94633cb6e2e0c324f833
+  Hyperdrive-Version: 4
+  ```
 
 ### URL Format
 
@@ -101,7 +109,7 @@ var getArchive = function (datInfo, cb) {
   cb(null, archive) // callback with your found archive
 }
 
-var onrequest = hyperdriveHttp(getArchive)
+var onrequest = hyperdriveHttp(getArchive, {exposeHeaders: true})
 var server = http.createServer()
 server.listen(8000)
 server.on('request', onrequest)


### PR DESCRIPTION
This adds the hypercore public key and version as HTTP headers in directory listings, e.g:

```http
$ curl -I http://localhost:8000
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
Content-Length: 975
Hyperdrive-Key: 40a588cebd28804d29828510c6a0fd8e2befc56ecfcf23028e57a201bfb3e727
Hyperdrive-Version: 4
Hyperdrive-Http-Version: 3.5.0
Date: Wed, 29 Mar 2017 20:16:46 GMT
Connection: keep-alive
```

I was considering `X-Hyperdrive-Key` etc as well, but as far as I know the `X-` prefix is no longer encouraged (sources: [1](http://stackoverflow.com/questions/3561381/custom-http-headers-naming-conventions), [2](https://tools.ietf.org/html/rfc6648)). 

The idea with this header is to have a CLI tool that you can just give the URL from hyperdrive-http, and the tool will automatically clone the hyperdrive based on the key in the header.